### PR TITLE
fix: week format and Windows NumpadEnter detection

### DIFF
--- a/src/keymap_windows.rs
+++ b/src/keymap_windows.rs
@@ -1,6 +1,11 @@
 use crate::keycode::KeyCode;
 
-pub fn map_vk(vk: u32) -> KeyCode {
+pub fn map_vk_extended(vk: u32, is_extended: bool) -> KeyCode {
+    // NumpadEnter is VK_RETURN (0x0D) with extended flag set
+    if vk == 0x0D && is_extended {
+        return KeyCode::NumpadEnter;
+    }
+
     match vk {
         // Letters (0x41-0x5A)
         0x41 => KeyCode::A,

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,7 +239,7 @@ fn print_terminal_report(data: &report::ReportData) {
     println!(
         "  Full report: {}/week-{}.html",
         reports_dir.display(),
-        data.week.start.format("%Y-W%W")
+        data.week.start.format("%Y-W%V")
     );
     println!();
 }
@@ -276,7 +276,7 @@ fn save_html_report(data: &report::ReportData) -> Result<()> {
 
     std::fs::create_dir_all(&reports_dir).context("failed to create reports directory")?;
 
-    let filename = format!("week-{}.html", data.week.start.format("%Y-W%W"));
+    let filename = format!("week-{}.html", data.week.start.format("%Y-W%V"));
     let filepath = reports_dir.join(&filename);
 
     let html = report::render_html(data);


### PR DESCRIPTION
Week format fix:
Changed %W (POSIX week, Sunday start) to %V (ISO week, Monday start) in report filename and terminal output. This ensures consistency with the ISO week parsing that uses from_isoywd_opt.

Windows NumpadEnter fix:
Added extended key flag detection in listener_windows.rs. The numpad Enter key sends VK_RETURN (0x0D) like regular Enter but with the LLKHF_EXTENDED flag set. Now correctly maps to KeyCode::NumpadEnter for accurate keyboard heatmap display.

Files changed:
  src/main.rs: %W to %V in two places
  src/listener_windows.rs: detect LLKHF_EXTENDED flag
  src/keymap_windows.rs: map_vk_extended handles NumpadEnter